### PR TITLE
do not fail if abort emits NoTransaction exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.9 (unreleased)
 ----------------
 
-- TBD
+- Avoid aborting at the end of a request if there is no active transaction.
+  See https://github.com/Pylons/pyramid_zodbconn/pull/10
 
 0.8 (2017-07-25)
 ----------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -100,3 +100,4 @@ Contributors
 - Chris McDonough, 2011/08/11
 - Domen Kožar, 2012/06/10
 - Steve Piercy, 2017/07/25
+- Michael Merickel, 2017/07/25

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
 ]
 
 docs_extras = ['Sphinx', 'pylons-sphinx-themes']
-testing_extras = ['nose', 'coverage']
+testing_extras = ['nose', 'coverage', 'pyramid_tm', 'webtest']
 
 setup(name='pyramid_zodbconn',
       version='0.9.dev0',


### PR DESCRIPTION
Sorry @tseaver but the previous fix wasn't quite enough. If an explicit manager is configured the final `abort` may raise an exception. The supplied test fails without this fix.

Also I noticed you haven't signed the contributors agreement. :-)